### PR TITLE
Treat Update Token as Password in the Database

### DIFF
--- a/app/Actions/Api/Auth/VerifyQuestionToken.php
+++ b/app/Actions/Api/Auth/VerifyQuestionToken.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Api\Auth;
 
 use App\Models\Core\Question;
+use Illuminate\Support\Facades\Hash;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class VerifyQuestionToken
@@ -14,7 +15,7 @@ class VerifyQuestionToken
         if (!$question) {
             return false;
         }
-        if ($question->update_token != $update_token) {
+        if(!Hash::check($update_token, $question->update_token)) {
             return false;
         }
         return true;

--- a/app/Http/Controllers/Api/Core/QuestionController.php
+++ b/app/Http/Controllers/Api/Core/QuestionController.php
@@ -18,7 +18,9 @@ use App\Models\User;
 use App\Services\Api\Core\Question\SearchQuestionService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
 
 // use Illuminate\Http\Request;
 
@@ -102,8 +104,10 @@ class QuestionController extends Controller
 
         // TODO: Include question tags and category.
 
+        $update_token = Str::uuid();
         $question = Question::create([
             'content' => $input['content'],
+            'update_token' => Hash::make($update_token),
         ]);
 
         $waitlister = new Waitlister([
@@ -113,6 +117,7 @@ class QuestionController extends Controller
         $question->waitlisters()->save($waitlister);
         
         //? Shall I refactor this part downwards or include above ones?
+        // TODO: Include naked update token in the email.
 
         Mail::to($input['email'])->queue(new AskedQuestion($waitlister, $question));
 
@@ -126,6 +131,7 @@ class QuestionController extends Controller
         return response()->json([
             'message' => 'Question created successfully.',
             'question' => $question,
+            'update_token' => $update_token, // TODO: Remove this later.
         ]);
     }
 

--- a/app/Models/Core/Question.php
+++ b/app/Models/Core/Question.php
@@ -18,6 +18,7 @@ class Question extends Model
         'category_id',
         'parent_answer_id',
         'content',
+        'update_token',
     ];
 
     public function uuidColumn(): string
@@ -25,10 +26,14 @@ class Question extends Model
         return 'uuid';
     }
 
-    public function uuidColumns(): array
-    {
-        return ['uuid', 'update_token'];
-    }
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'update_token',
+    ];
 
     /**
      * Relationships

--- a/database/migrations/2022_07_22_053900_create_questions_table.php
+++ b/database/migrations/2022_07_22_053900_create_questions_table.php
@@ -20,7 +20,7 @@ class CreateQuestionsTable extends Migration
             $table->integer('parent_answer_id')->nullable()->comment("In case a user seeks a follow-up question based from the answer given.");
             $table->integer('duplicate_question_id')->nullable()->comment("If a question is a duplicate of an existing question, then this will refer to it. Duplicate questions are hidden in search results.");
             $table->text('content');
-            $table->uuid('update_token')->comment("This token is sent to the question owners email which gives him/her control to update/delete the question as long as the question does not have any answers yet.");
+            $table->text('update_token')->comment("This token is sent to the question owners email which gives him/her control to update/delete the question as long as the question does not have any answers yet.");
             $table->timestamps();
             $table->softDeletes();
         });


### PR DESCRIPTION
This adds an extra layer of security for question owners as question's update token is stored in the database in bcrypt format. The update token doesn't necessarily be shown up again so it makes sense to treat update token like a password by checking the appended update token in the URL from the hashed update token.